### PR TITLE
Fixes to multiplayer docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,4 @@
-FROM ubuntu:18.04
-
-# Fixes libcurl.so.4 dependency issue.
-RUN apt-get update && apt-get install -y \
-    wget libcurl4-openssl-dev libsdl2-dev
+FROM citraemu/build-environments:linux-fresh
 
 # Create app directory
 WORKDIR /usr/src/app

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Quickly stand up new dedicated multiplayer lobbies that will be broadcasted on C
 ## Usage
 ```
 sudo docker run -d \
-  --publish 5000:5000/udp
+  --publish 5000:5000/udp \
   citraemu/citra-multiplayer-dedicated \
   --room-name "(COUNTRY) (REGION) - GAME TITLE" \
   --preferred-game "GAME TITLE" \


### PR DESCRIPTION
1. Fixed dependency issues caused by having core linked in. The image is now directly built from the same image used to build citra.
1. Fixed small error in README.md.